### PR TITLE
refactor: align module with school namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# thebrains
+# School Management Module
+
+This repository contains an Odoo 18.0 add-on that introduces campus and faculty management screens. Faculties can be linked to multiple campuses directly from the creation form through a many-to-many selector.
+
+## Installation
+1. Copy the `school` directory into your Odoo add-ons path.
+2. Update the app list from the Odoo interface.
+3. Install **School Management** from the Apps menu.
+
+## Usage
+* Navigate to **School → Campuses** to manage campuses.
+* Navigate to **School → Faculties** to create or update faculties and assign the campuses where each faculty is established.
+
+All labels and help messages are provided in English to match the requested application language.

--- a/school/__init__.py
+++ b/school/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/school/__manifest__.py
+++ b/school/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    "name": "School Management",
+    "version": "18.0.1.0.0",
+    "summary": "School management helpers for campuses and faculties.",
+    "category": "Education",
+    "author": "TheBrains",
+    "website": "https://example.com",
+    "license": "LGPL-3",
+    "depends": ["base"],
+    "data": [
+        "views/campus_views.xml",
+        "views/faculty_views.xml",
+    ],
+    "application": False,
+}

--- a/school/models/__init__.py
+++ b/school/models/__init__.py
@@ -1,0 +1,2 @@
+from . import campus
+from . import faculty

--- a/school/models/campus.py
+++ b/school/models/campus.py
@@ -1,0 +1,20 @@
+from odoo import fields, models
+
+
+class Campus(models.Model):
+    _name = "school.campus"
+    _description = "Campus"
+
+    name = fields.Char(required=True, translate=False)
+    code = fields.Char(required=True, translate=False)
+    faculty_ids = fields.Many2many(
+        comodel_name="school.faculty",
+        relation="school_faculty_campus_rel",
+        column1="campus_id",
+        column2="faculty_id",
+        string="Faculties",
+    )
+
+    _sql_constraints = [
+        ("code_unique", "unique(code)", "The campus code must be unique."),
+    ]

--- a/school/models/faculty.py
+++ b/school/models/faculty.py
@@ -1,0 +1,26 @@
+from odoo import fields, models
+
+
+class Faculty(models.Model):
+    _name = "school.faculty"
+    _description = "Faculty"
+
+    name = fields.Char(required=True, translate=False)
+    reference = fields.Char(required=True, translate=False)
+    campus_ids = fields.Many2many(
+        comodel_name="school.campus",
+        relation="school_faculty_campus_rel",
+        column1="faculty_id",
+        column2="campus_id",
+        string="Campuses",
+        help="Select all campuses where this faculty is established.",
+    )
+    dean_id = fields.Many2one(
+        comodel_name="res.partner",
+        string="Dean",
+        help="Assign the faculty dean if already defined.",
+    )
+
+    _sql_constraints = [
+        ("reference_unique", "unique(reference)", "The faculty reference must be unique."),
+    ]

--- a/school/views/campus_views.xml
+++ b/school/views/campus_views.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_school_campus_tree" model="ir.ui.view">
+        <field name="name">school.campus.tree</field>
+        <field name="model">school.campus</field>
+        <field name="arch" type="xml">
+            <tree string="Campuses">
+                <field name="name"/>
+                <field name="code"/>
+                <field name="faculty_ids" widget="many2many_tags"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_school_campus_form" model="ir.ui.view">
+        <field name="name">school.campus.form</field>
+        <field name="model">school.campus</field>
+        <field name="arch" type="xml">
+            <form string="Campus">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="code"/>
+                    </group>
+                    <group string="Faculties">
+                        <field name="faculty_ids" widget="many2many_tags"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_school_campus" model="ir.actions.act_window">
+        <field name="name">Campuses</field>
+        <field name="res_model">school.campus</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem id="menu_school_root" name="School" sequence="10"/>
+    <menuitem id="menu_school_campus" name="Campuses" parent="menu_school_root" action="action_school_campus" sequence="10"/>
+</odoo>

--- a/school/views/faculty_views.xml
+++ b/school/views/faculty_views.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_school_faculty_tree" model="ir.ui.view">
+        <field name="name">school.faculty.tree</field>
+        <field name="model">school.faculty</field>
+        <field name="arch" type="xml">
+            <tree string="Faculties">
+                <field name="name"/>
+                <field name="reference"/>
+                <field name="campus_ids" widget="many2many_tags"/>
+                <field name="dean_id"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_school_faculty_form" model="ir.ui.view">
+        <field name="name">school.faculty.form</field>
+        <field name="model">school.faculty</field>
+        <field name="arch" type="xml">
+            <form string="Faculty">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="reference"/>
+                        <field name="dean_id" options="{'no_create': False}"/>
+                    </group>
+                    <group string="Campuses">
+                        <field name="campus_ids" widget="many2many_tags" options="{'no_create': False}"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_school_faculty" model="ir.actions.act_window">
+        <field name="name">Faculties</field>
+        <field name="res_model">school.faculty</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem id="menu_school_faculty" name="Faculties" parent="menu_school_root" action="action_school_faculty" sequence="20"/>
+</odoo>


### PR DESCRIPTION
## Summary
- rename the addon directory to `school` and refresh the English README instructions
- update the manifest and models to use the `school` namespace and relation table
- adjust the campus and faculty menus and views so multi-campus selection lives under the School menu

## Testing
- not run (Odoo environment not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68dd0af3cb30832cb03b4320b29e30e7