### PR TITLE
Allow faculties to span multiple campuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# thebrains
+# School Management Module
+
+This repository contains an Odoo module dedicated to managing an academic structure
+with multiple campuses. The module provides models for campuses, faculties,
+specialities, and additional academic entities required to manage schedules and
+staff assignments.
+
+## Key Features
+
+- Maintain the list of campuses with geolocation and staff assignments.
+- Create faculties that can now operate across multiple campuses through a
+  dedicated multi-selection field.
+- Manage specialities, cursus, levels, semesters, and courses linked to the
+  appropriate faculty.
+- Track faculty heads with automatic synchronization of contact details.
+- Access all records through list, form, and kanban views for efficient daily
+  operations.
+
+## Multi-Campus Faculties
+
+When creating or editing a faculty, select all the campuses where the faculty is
+established. This information is automatically reflected on the related campus
+records, ensuring consistency across the application.
+
+## Installation
+
+1. Install the module in your Odoo instance (supported with the `hr` and `mail`
+   applications).
+2. Update the apps list and search for **School**.
+3. Install the module and start organizing your academic schedules.
+
+## License
+
+This module is distributed under the LGPL-3 license.

--- a/school/models/campus.py
+++ b/school/models/campus.py
@@ -32,8 +32,12 @@ class Campus(models.Model):
         "brains.employee.campus", "campus_id", string="Affectations"
     )
 
-    faculty_ids = fields.One2many(
-        "brains.faculty", "campus_id", string="Faculty", tracking=True, store=True
+    faculty_ids = fields.Many2many(
+        "brains.faculty",
+        "brains_campus_faculty_rel",
+        "campus_id",
+        "faculty_id",
+        string="Faculties",
     )
 
 
@@ -124,8 +128,14 @@ class Faculty(models.Model):
     employee_email = fields.Char(related="employee_id.email", string="Email", store=True)
     employee_phone = fields.Char(related="employee_id.phone", string="Phone", store=True)
 
-
-    campus_id = fields.Many2one("brains.campus", string="Campus", required=True)
+    campus_ids = fields.Many2many(
+        "brains.campus",
+        "brains_campus_faculty_rel",
+        "faculty_id",
+        "campus_id",
+        string="Campuses",
+        required=True,
+    )
     speciality_ids = fields.One2many(
         "brains.speciality", "faculty_id", string="Speciality"
     )

--- a/school/views/campus.xml
+++ b/school/views/campus.xml
@@ -198,6 +198,7 @@
         <field name="arch" type="xml">
             <list>
                 <field name="name"/>
+                <field name="campus_ids" widget="many2many_tags"/>
                 <field name="employee_id"/>
                 <field name="employee_email"/>
                 <field name="employee_phone"/>
@@ -214,7 +215,7 @@
                 <sheet>
                     <group string="Informations">
                         <field name="name"/>
-                        <field name="campus_id"/>
+                        <field name="campus_ids" widget="many2many_tags" options="{'no_create': False}"/>
                         <field name="employee_id"/>
                         <field name="employee_email"/>
                         <field name="employee_phone"/>
@@ -243,7 +244,7 @@
             <!-- <kanban default_group_by="campus_id"> -->
             <kanban>
                 <field name="name"/>
-                <field name="campus_id"/>
+                <field name="campus_ids"/>
                 <field name="employee_id"/>
                 <field name="employee_email"/>
                 <field name="employee_phone"/>
@@ -257,7 +258,10 @@
 
                             <!-- Détails -->
                             <div class="o_kanban_details">
-                                <div><span class="o_label">Campus :</span> <field name="campus_id"/></div>
+                                <div>
+                                    <span class="o_label">Campuses :</span>
+                                    <field name="campus_ids" widget="many2many_tags"/>
+                                </div>
                                 <div><span class="o_label">Responsable :</span> <field name="employee_id"/></div>
                                 <div><span class="o_label">Email :</span> <field name="employee_email"/></div>
                                 <div><span class="o_label">Téléphone :</span> <field name="employee_phone"/></div>
@@ -277,7 +281,7 @@
             <search>
                 <!-- Champs recherchables -->
                 <field name="name" string="Faculty"/>
-                <field name="campus_id" string="Campus"/>
+                <field name="campus_ids" string="Campuses"/>
                 <field name="employee_id" string="Responsable"/>
                 <field name="employee_email" string="Email"/>
                 <field name="employee_phone" string="Téléphone"/>
@@ -288,8 +292,6 @@
 
                 <!-- Group By -->
                 <group expand="0" string="Regrouper par">
-                    <filter name="group_by_campus" string="Campus"
-                            context="{'group_by':'campus_id'}"/>
                     <filter name="group_by_responsable" string="Responsable"
                             context="{'group_by':'employee_id'}"/>
                 </group>


### PR DESCRIPTION
## Summary
- add a many2many relationship between faculties and campuses to support multi-campus assignments
- update faculty views to expose the new campus selector and reflect the relationship in kanban/list/search views
- refresh the README with English documentation covering the multi-campus capability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd1239cb58832c8426964db41cfae5