### PR TITLE
Allow linking specialities to faculties and campuses

### DIFF
--- a/school/models/speciality.py
+++ b/school/models/speciality.py
@@ -14,4 +14,13 @@ class Speciality(models.Model):
 
     faculty_id = fields.Many2one("brains.faculty", string="Faculty", required=True)
 
+    campus_ids = fields.Many2many(
+        "brains.campus",
+        "brains_speciality_campus_rel",
+        "speciality_id",
+        "campus_id",
+        string="Campuses",
+    )
+
     cursus_ids = fields.One2many("brains.cursus", "speciality_id", string="Cursus")
+

--- a/school/views/speciality.xml
+++ b/school/views/speciality.xml
@@ -9,6 +9,7 @@
                 <field name="name"/>
                 <field name="faculty_id"/>
                 <field name="guardiadhip"/>
+                <field name="campus_ids" widget="many2many_tags"/>
             </list>
         </field>
     </record>
@@ -22,8 +23,9 @@
                 <sheet>
                     <group string="Informations">
                         <field name="name"/>
-                        <field name="faculty_id"/>
+                        <field name="faculty_id" options="{'no_create': True, 'no_create_edit': True}"/>
                         <field name="guardiadhip"/>
+                        <field name="campus_ids" widget="many2many_tags" domain="[('faculty_ids', 'in', faculty_id)]"/>
                     </group>
                     <notebook>
                         <page string="Cursus">


### PR DESCRIPTION
## Summary
- add a campuses many2many relation to specialities so filières can be assigned to multiple campuses
- prevent creating a faculty from the speciality form to ensure filières attach to existing faculties
- expose the new campus selection across speciality views with tag widgets and a faculty-based domain

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd164f6cdc832c8a55955c5a9a7f44