### PR TITLE
Link courses to faculties and manage teacher assignments

### DIFF
--- a/school/models/__init__.py
+++ b/school/models/__init__.py
@@ -5,3 +5,4 @@ from . import level
 from . import semestre
 from . import year_sca
 from . import cours
+from . import teacher_course

--- a/school/models/campus.py
+++ b/school/models/campus.py
@@ -88,6 +88,9 @@ class EmployeeHenrit(models.Model):
     )
     is_teacher = fields.Boolean(string="Is Teacher ?")
     is_student = fields.Boolean(string="Is Student ?")
+    teacher_course_ids = fields.One2many(
+        "brains.teacher.course", "teacher_id", string="Courses"
+    )
 
     
 

--- a/school/models/cours.py
+++ b/school/models/cours.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from odoo import models, fields
+from odoo import models, fields, api
 
 class Cour(models.Model):
     _name = "brains.cours"
@@ -56,6 +56,26 @@ class Cour(models.Model):
         tracking=True
     )
 
+    faculty_id = fields.Many2one(
+        "brains.faculty",
+        related="specialty_id.faculty_id",
+        string="Faculty",
+        store=True,
+        readonly=True,
+        tracking=True,
+    )
+
+    campus_ids = fields.Many2many(
+        "brains.campus",
+        "brains_course_campus_rel",
+        "course_id",
+        "campus_id",
+        string="Campuses",
+        compute="_compute_campus_ids",
+        store=True,
+        readonly=True,
+    )
+
     semester_id = fields.Many2one(
         "brains.semestre",
         string="Semester",
@@ -69,3 +89,9 @@ class Cour(models.Model):
         required=True,
         tracking=True
     )
+
+    @api.depends("specialty_id.campus_ids", "faculty_id.campus_ids")
+    def _compute_campus_ids(self):
+        for course in self:
+            campuses = course.specialty_id.campus_ids | course.faculty_id.campus_ids
+            course.campus_ids = campuses

--- a/school/models/teacher_course.py
+++ b/school/models/teacher_course.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from odoo import models, fields, api
+from odoo.exceptions import ValidationError
+
+
+class TeacherCourse(models.Model):
+    _name = "brains.teacher.course"
+    _description = "Teacher Course Assignment"
+
+    teacher_id = fields.Many2one(
+        "hr.employee",
+        string="Teacher",
+        required=True,
+        domain=[('is_teacher', '=', True)],
+        ondelete="cascade",
+    )
+    course_id = fields.Many2one(
+        "brains.cours",
+        string="Course",
+        required=True,
+        ondelete="cascade",
+    )
+    campus_ids = fields.Many2many(
+        "brains.campus",
+        "brains_teacher_course_campus_rel",
+        "assignment_id",
+        "campus_id",
+        string="Campuses",
+    )
+
+    _sql_constraints = [
+        (
+            "teacher_course_unique",
+            "unique(teacher_id, course_id)",
+            "This teacher is already assigned to this course.",
+        )
+    ]
+
+    @api.constrains("campus_ids", "course_id")
+    def _check_campuses_within_course(self):
+        for record in self:
+            if record.course_id and record.campus_ids:
+                invalid_campuses = record.campus_ids - record.course_id.campus_ids
+                if invalid_campuses:
+                    raise ValidationError(
+                        "Selected campuses must be part of the course's campuses."
+                    )
+
+    @api.onchange("course_id")
+    def _onchange_course_id(self):
+        if self.course_id:
+            self.campus_ids = self.course_id.campus_ids
+        else:
+            self.campus_ids = False

--- a/school/security/ir.model.access.csv
+++ b/school/security/ir.model.access.csv
@@ -10,3 +10,4 @@ access_brains_semestre_user,access.brains.semestre,model_brains_semestre,,1,1,1,
 access_brains_level_user,access.brains.level,model_brains_level,,1,1,1,1
 access_brains_year_sca_user,access.brains.school.year,model_brains_school_year,,1,1,1,1
 access_brains_cours_user,access.brains.cours,model_brains_cours,,1,1,1,1
+access_brains_teacher_course_user,access.brains.teacher.course,model_brains_teacher_course,,1,1,1,1

--- a/school/views/cours.xml
+++ b/school/views/cours.xml
@@ -12,6 +12,8 @@
                 <field name="semester_id"/>
                 <field name="cursus_id"/>
                 <field name="specialty_id"/>
+                <field name="faculty_id"/>
+                <field name="campus_ids" widget="many2many_tags"/>
                 <field name="years_id"/>
                 <field name="responsible_id"/>
                 <field name="type_cours"/>
@@ -40,6 +42,8 @@
                         <field name="semester_id" domain="[('year_ids','=',years_id)]"/>
                         <field name="cursus_id" />
                         <field name="specialty_id" />
+                        <field name="faculty_id" readonly="1"/>
+                        <field name="campus_ids" widget="many2many_tags" readonly="1"/>
                         <field name="level_id" />
                     </group>
                     <group string="Details">
@@ -65,6 +69,8 @@
                 <field name="semester_id"/>
                 <field name="cursus_id"/>
                 <field name="years_id"/>
+                <field name="faculty_id"/>
+                <field name="campus_ids"/>
                 <field name="responsible_id"/>
                 <field name="type_cours"/>
                 <field name="credits"/>

--- a/school/views/employee.xml
+++ b/school/views/employee.xml
@@ -144,9 +144,23 @@
                         </list>
                     </field>
                 </page>
+                <page string="Cours enseignés" attrs="{'invisible': [('is_teacher', '=', False)]}">
+                    <field name="teacher_course_ids" context="{'default_teacher_id': active_id}">
+                        <tree editable="bottom">
+                            <field name="course_id"/>
+                            <field name="campus_ids" widget="many2many_tags" domain="[('id', 'in', course_id.campus_ids.ids)]"/>
+                        </tree>
+                        <form string="Cours enseigné">
+                            <group>
+                                <field name="course_id"/>
+                                <field name="campus_ids" widget="many2many_tags" domain="[('id', 'in', course_id.campus_ids.ids)]"/>
+                            </group>
+                        </form>
+                    </field>
+                </page>
             </xpath>
         </field>
-        </record>   
+        </record>
 
     <!-- Menus-->
     <!-- <menuitem id="menu_brains_employee" name="Employes" parent="menu_brains_root" action="action_employee"/> -->


### PR DESCRIPTION
## Summary
- automatically link courses to their faculty and inherited campuses from the selected filiere
- expose the faculty and campus information in course views for quick validation
- add teacher course assignment model and UI to assign teachers to courses and campuses with security access

## Testing
- python3 -m compileall school

------
https://chatgpt.com/codex/tasks/task_e_68dd45fa657c832c87964f2b43425a14