### PR TITLE
Ensure specialities link to faculties and campuses

### DIFF
--- a/school/models/speciality.py
+++ b/school/models/speciality.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-from odoo import models, fields
+from odoo import models, fields, api
+from odoo.exceptions import ValidationError
 
 class Speciality(models.Model):
     _name = "brains.speciality"
-    _description ="Speciality"
+    _description = "Speciality"
     _inherit = [
         'mail.thread',
         'mail.activity.mixin',
@@ -20,7 +21,37 @@ class Speciality(models.Model):
         "speciality_id",
         "campus_id",
         string="Campuses",
+        required=True,
     )
 
     cursus_ids = fields.One2many("brains.cursus", "speciality_id", string="Cursus")
+
+    @api.onchange("faculty_id")
+    def _onchange_faculty_id(self):
+        """Reset the selected campuses when the faculty changes.
+
+        Only campuses linked to the chosen faculty should remain selected to
+        avoid inconsistent data when the user changes the faculty.
+        """
+        if self.faculty_id:
+            allowed_campuses = self.faculty_id.campus_ids
+            self.campus_ids = self.campus_ids & allowed_campuses
+        else:
+            self.campus_ids = False
+
+    @api.constrains("campus_ids", "faculty_id")
+    def _check_campus_faculty_alignment(self):
+        for speciality in self:
+            if not speciality.campus_ids:
+                raise ValidationError(
+                    "Veuillez sélectionner au moins un campus pour la filière."
+                )
+
+            invalid_campuses = speciality.campus_ids.filtered(
+                lambda campus: speciality.faculty_id not in campus.faculty_ids
+            )
+            if invalid_campuses:
+                raise ValidationError(
+                    "Les campus sélectionnés doivent être rattachés à la faculté choisie."
+                )
 

--- a/school/views/speciality.xml
+++ b/school/views/speciality.xml
@@ -25,7 +25,10 @@
                         <field name="name"/>
                         <field name="faculty_id" options="{'no_create': True, 'no_create_edit': True}"/>
                         <field name="guardiadhip"/>
-                        <field name="campus_ids" widget="many2many_tags" domain="[('faculty_ids', 'in', faculty_id)]"/>
+                        <field name="campus_ids"
+                               widget="many2many_tags"
+                               domain="[('faculty_ids', 'in', faculty_id)]"
+                               options="{'no_create': True, 'no_create_edit': True}"/>
                     </group>
                     <notebook>
                         <page string="Cursus">


### PR DESCRIPTION
## Summary
- enforce that specialities are tied to existing faculties and at least one campus
- restrict campus selections to those linked to the faculty and clear invalid options when the faculty changes
- disable on-the-fly creation of campuses from the speciality form

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de424c67c8832c98f97d162b227a97