### PR TITLE
Add class and timetable management for school module

### DIFF
--- a/school/__manifest__.py
+++ b/school/__manifest__.py
@@ -22,6 +22,8 @@ This module .
         'views/semestre.xml',
         'views/year_sca.xml',
         'views/cours.xml',
+        'views/classroom.xml',
+        'views/timetable.xml',
         'views/menu.xml',
     ],
     'images': [

--- a/school/models/__init__.py
+++ b/school/models/__init__.py
@@ -6,3 +6,5 @@ from . import semestre
 from . import year_sca
 from . import cours
 from . import teacher_course
+from . import classroom
+from . import timetable

--- a/school/models/classroom.py
+++ b/school/models/classroom.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class Classroom(models.Model):
+    _name = "brains.classroom"
+    _description = "Class"
+    _inherit = [
+        'mail.thread',
+        'mail.activity.mixin',
+    ]
+
+    name = fields.Char(
+        string="Name",
+        compute="_compute_name",
+        store=True,
+        tracking=True,
+    )
+    code = fields.Char(string="Code", tracking=True)
+    campus_id = fields.Many2one(
+        "brains.campus",
+        string="Campus",
+        required=True,
+        tracking=True,
+    )
+    semester_id = fields.Many2one(
+        "brains.semestre",
+        string="Semester",
+        required=True,
+        tracking=True,
+    )
+    year_id = fields.Many2one(
+        "brains.school.year",
+        string="Academic Year",
+        required=True,
+        tracking=True,
+    )
+    level_id = fields.Many2one(
+        "brains.level",
+        string="Level",
+        related="semester_id.level_id",
+        store=True,
+        readonly=True,
+        tracking=True,
+    )
+    cursus_id = fields.Many2one(
+        "brains.cursus",
+        string="Cursus",
+        related="semester_id.cursus_id",
+        store=True,
+        readonly=True,
+        tracking=True,
+    )
+    speciality_id = fields.Many2one(
+        "brains.speciality",
+        string="Speciality",
+        related="semester_id.speciality_id",
+        store=True,
+        readonly=True,
+        tracking=True,
+    )
+    faculty_id = fields.Many2one(
+        "brains.faculty",
+        string="Faculty",
+        related="speciality_id.faculty_id",
+        store=True,
+        readonly=True,
+        tracking=True,
+    )
+    student_ids = fields.Many2many(
+        "hr.employee",
+        "brains_classroom_student_rel",
+        "classroom_id",
+        "student_id",
+        string="Students",
+        domain=[('is_student', '=', True)],
+        tracking=True,
+    )
+    teacher_ids = fields.Many2many(
+        "hr.employee",
+        "brains_classroom_teacher_rel",
+        "classroom_id",
+        "teacher_id",
+        string="Teachers",
+        domain=[('is_teacher', '=', True)],
+        tracking=True,
+    )
+    timetable_ids = fields.One2many(
+        "brains.timetable",
+        "classroom_id",
+        string="Timetables",
+    )
+
+    _sql_constraints = [
+        (
+            "unique_classroom_per_semester_year_campus",
+            "unique(semester_id, year_id, campus_id)",
+            "A class already exists for this semester, year and campus.",
+        )
+    ]
+
+    @api.depends("semester_id", "year_id", "campus_id")
+    def _compute_name(self):
+        for classroom in self:
+            parts = []
+            if classroom.semester_id:
+                parts.append(classroom.semester_id.name)
+            if classroom.year_id:
+                parts.append(classroom.year_id.name)
+            if classroom.campus_id:
+                parts.append(classroom.campus_id.name)
+            classroom.name = " - ".join(parts) if parts else False
+
+    @api.constrains("semester_id", "year_id")
+    def _check_year_in_semester(self):
+        for classroom in self:
+            if classroom.semester_id and classroom.year_id:
+                if classroom.year_id not in classroom.semester_id.year_ids:
+                    raise ValidationError(
+                        "The selected academic year is not linked to the semester.",
+                    )
+
+    @api.constrains("student_ids")
+    def _check_student_roles(self):
+        for classroom in self:
+            invalid_students = classroom.student_ids.filtered(lambda s: not s.is_student)
+            if invalid_students:
+                raise ValidationError(
+                    "All members assigned to a class as students must have the student role.",
+                )
+
+    @api.constrains("teacher_ids")
+    def _check_teacher_roles(self):
+        for classroom in self:
+            invalid_teachers = classroom.teacher_ids.filtered(lambda t: not t.is_teacher)
+            if invalid_teachers:
+                raise ValidationError(
+                    "All members assigned to a class as teachers must have the teacher role.",
+                )

--- a/school/models/cours.py
+++ b/school/models/cours.py
@@ -91,6 +91,12 @@ class Cour(models.Model):
         tracking=True
     )
 
+    teacher_course_ids = fields.One2many(
+        "brains.teacher.course",
+        "course_id",
+        string="Teacher Assignments",
+    )
+
     @api.depends("specialty_id.campus_ids", "faculty_id.campus_ids")
     def _compute_campus_ids(self):
         for course in self:

--- a/school/models/timetable.py
+++ b/school/models/timetable.py
@@ -1,0 +1,231 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class Timetable(models.Model):
+    _name = "brains.timetable"
+    _description = "Class Timetable"
+    _inherit = [
+        'mail.thread',
+        'mail.activity.mixin',
+    ]
+    _order = "start_datetime"
+
+    name = fields.Char(
+        string="Description",
+        compute="_compute_name",
+        store=True,
+        tracking=True,
+    )
+    classroom_id = fields.Many2one(
+        "brains.classroom",
+        string="Class",
+        required=True,
+        tracking=True,
+        ondelete="cascade",
+    )
+    course_id = fields.Many2one(
+        "brains.cours",
+        string="Course",
+        required=True,
+        tracking=True,
+    )
+    teacher_id = fields.Many2one(
+        "hr.employee",
+        string="Teacher",
+        required=True,
+        domain=[('is_teacher', '=', True)],
+        tracking=True,
+    )
+    campus_id = fields.Many2one(
+        "brains.campus",
+        related="classroom_id.campus_id",
+        string="Campus",
+        store=True,
+        readonly=True,
+        tracking=True,
+    )
+    level_id = fields.Many2one(
+        "brains.level",
+        related="classroom_id.level_id",
+        string="Level",
+        store=True,
+        readonly=True,
+        tracking=True,
+    )
+    semester_id = fields.Many2one(
+        "brains.semestre",
+        related="classroom_id.semester_id",
+        string="Semester",
+        store=True,
+        readonly=True,
+        tracking=True,
+    )
+    cursus_id = fields.Many2one(
+        "brains.cursus",
+        related="classroom_id.cursus_id",
+        string="Cursus",
+        store=True,
+        readonly=True,
+        tracking=True,
+    )
+    year_id = fields.Many2one(
+        "brains.school.year",
+        related="classroom_id.year_id",
+        string="Academic Year",
+        store=True,
+        readonly=True,
+        tracking=True,
+    )
+    speciality_id = fields.Many2one(
+        "brains.speciality",
+        related="classroom_id.speciality_id",
+        string="Speciality",
+        store=True,
+        readonly=True,
+        tracking=True,
+    )
+    start_datetime = fields.Datetime(
+        string="Start",
+        required=True,
+        tracking=True,
+    )
+    end_datetime = fields.Datetime(
+        string="End",
+        required=True,
+        tracking=True,
+    )
+    location = fields.Char(string="Location", tracking=True)
+    notes = fields.Text(string="Notes", tracking=True)
+
+    _sql_constraints = [
+        (
+            "teacher_course_unique_slot",
+            "unique(classroom_id, course_id, teacher_id, start_datetime, end_datetime)",
+            "This timetable entry is already defined.",
+        )
+    ]
+
+    @api.depends("classroom_id", "course_id", "start_datetime")
+    def _compute_name(self):
+        for timetable in self:
+            parts = []
+            if timetable.classroom_id:
+                parts.append(timetable.classroom_id.name)
+            if timetable.course_id:
+                parts.append(timetable.course_id.name)
+            if timetable.start_datetime:
+                parts.append(fields.Datetime.to_string(timetable.start_datetime))
+            timetable.name = " - ".join(parts) if parts else False
+
+    @api.constrains("start_datetime", "end_datetime")
+    def _check_chronology(self):
+        for timetable in self:
+            if timetable.start_datetime and timetable.end_datetime:
+                if timetable.start_datetime >= timetable.end_datetime:
+                    raise ValidationError("The end time must be after the start time.")
+
+    @api.constrains("course_id", "semester_id", "year_id")
+    def _check_course_semester_year(self):
+        for timetable in self:
+            if timetable.course_id and timetable.semester_id:
+                if timetable.course_id.semester_id != timetable.semester_id:
+                    raise ValidationError(
+                        "The course must belong to the same semester as the class.",
+                    )
+            if timetable.course_id and timetable.year_id:
+                if timetable.course_id.years_id != timetable.year_id:
+                    raise ValidationError(
+                        "The course must belong to the same academic year as the class.",
+                    )
+            if timetable.course_id and timetable.campus_id:
+                if timetable.campus_id not in timetable.course_id.campus_ids:
+                    raise ValidationError(
+                        "The course is not available for the selected campus.",
+                    )
+
+    @api.constrains("teacher_id", "course_id")
+    def _check_teacher_course_assignment(self):
+        for timetable in self:
+            if timetable.teacher_id and timetable.course_id:
+                assignments = timetable.course_id.teacher_course_ids.filtered(
+                    lambda assignment: assignment.teacher_id == timetable.teacher_id
+                )
+                if not assignments:
+                    if timetable.course_id.responsible_id != timetable.teacher_id:
+                        raise ValidationError(
+                            "The teacher is not assigned to the selected course.",
+                        )
+                else:
+                    if timetable.campus_id and not any(
+                        timetable.campus_id in assignment.campus_ids
+                        for assignment in assignments
+                    ):
+                        raise ValidationError(
+                            "The teacher is not assigned to this course for the selected campus.",
+                        )
+
+    @api.constrains("classroom_id", "start_datetime", "end_datetime")
+    def _check_classroom_overlap(self):
+        for timetable in self:
+            if timetable.classroom_id and timetable.start_datetime and timetable.end_datetime:
+                domain = [
+                    ("classroom_id", "=", timetable.classroom_id.id),
+                    ("id", "!=", timetable.id),
+                    ("start_datetime", "<", timetable.end_datetime),
+                    ("end_datetime", ">", timetable.start_datetime),
+                ]
+                conflict = self.search_count(domain)
+                if conflict:
+                    raise ValidationError(
+                        "The class already has a timetable entry during this period.",
+                    )
+
+    @api.constrains("teacher_id", "start_datetime", "end_datetime")
+    def _check_teacher_overlap(self):
+        for timetable in self:
+            if timetable.teacher_id and timetable.start_datetime and timetable.end_datetime:
+                domain = [
+                    ("teacher_id", "=", timetable.teacher_id.id),
+                    ("id", "!=", timetable.id),
+                    ("start_datetime", "<", timetable.end_datetime),
+                    ("end_datetime", ">", timetable.start_datetime),
+                ]
+                conflict = self.search_count(domain)
+                if conflict:
+                    raise ValidationError(
+                        "The teacher is already scheduled during this period.",
+                    )
+
+    @api.onchange("course_id")
+    def _onchange_course_id(self):
+        if self.course_id:
+            if self.course_id.responsible_id:
+                self.teacher_id = self.course_id.responsible_id
+            domain = [
+                ("semester_id", "=", self.course_id.semester_id.id),
+            ]
+            if self.course_id.years_id:
+                domain.append(("year_id", "=", self.course_id.years_id.id))
+            return {
+                "domain": {
+                    "classroom_id": domain,
+                }
+            }
+        return {}
+
+    @api.onchange("classroom_id")
+    def _onchange_classroom_id(self):
+        if self.classroom_id:
+            domain = [
+                ("semester_id", "=", self.classroom_id.semester_id.id),
+            ]
+            if self.classroom_id.year_id:
+                domain.append(("years_id", "=", self.classroom_id.year_id.id))
+            return {
+                "domain": {
+                    "course_id": domain,
+                }
+            }
+        return {}

--- a/school/security/ir.model.access.csv
+++ b/school/security/ir.model.access.csv
@@ -11,3 +11,5 @@ access_brains_level_user,access.brains.level,model_brains_level,,1,1,1,1
 access_brains_year_sca_user,access.brains.school.year,model_brains_school_year,,1,1,1,1
 access_brains_cours_user,access.brains.cours,model_brains_cours,,1,1,1,1
 access_brains_teacher_course_user,access.brains.teacher.course,model_brains_teacher_course,,1,1,1,1
+access_brains_classroom_user,access.brains.classroom,model_brains_classroom,,1,1,1,1
+access_brains_timetable_user,access.brains.timetable,model_brains_timetable,,1,1,1,1

--- a/school/views/classroom.xml
+++ b/school/views/classroom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- LIST VIEW -->
+    <record id="view_brains_classroom_list" model="ir.ui.view">
+        <field name="name">brains.classroom.list</field>
+        <field name="model">brains.classroom</field>
+        <field name="arch" type="xml">
+            <list string="Classes" default_order="name asc">
+                <field name="name"/>
+                <field name="campus_id"/>
+                <field name="semester_id"/>
+                <field name="year_id"/>
+                <field name="level_id"/>
+                <field name="cursus_id"/>
+                <field name="speciality_id"/>
+                <field name="faculty_id"/>
+                <field name="student_ids" widget="many2many_tags"/>
+                <field name="teacher_ids" widget="many2many_tags"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- FORM VIEW -->
+    <record id="view_brains_classroom_form" model="ir.ui.view">
+        <field name="name">brains.classroom.form</field>
+        <field name="model">brains.classroom</field>
+        <field name="arch" type="xml">
+            <form string="Class">
+                <sheet>
+                    <group string="Identification">
+                        <field name="name" readonly="1"/>
+                        <field name="code"/>
+                        <field name="campus_id"/>
+                    </group>
+                    <group string="Academic Information" colspan="2">
+                        <field name="year_id"/>
+                        <field name="semester_id" domain="[('year_ids','=',year_id)]"/>
+                        <field name="level_id" readonly="1"/>
+                        <field name="cursus_id" readonly="1"/>
+                        <field name="speciality_id" readonly="1"/>
+                        <field name="faculty_id" readonly="1"/>
+                    </group>
+                    <notebook>
+                        <page string="Students">
+                            <field name="student_ids" widget="many2many_tags"
+                                   context="{'default_is_student': True}"/>
+                        </page>
+                        <page string="Teachers">
+                            <field name="teacher_ids" widget="many2many_tags"
+                                   context="{'default_is_teacher': True}"/>
+                        </page>
+                        <page string="Timetables">
+                            <field name="timetable_ids">
+                                <tree editable="bottom">
+                                    <field name="start_datetime"/>
+                                    <field name="end_datetime"/>
+                                    <field name="course_id"/>
+                                    <field name="teacher_id"/>
+                                    <field name="location"/>
+                                </tree>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+                <chatter reload_on_follower="True"/>
+            </form>
+        </field>
+    </record>
+
+    <!-- SEARCH VIEW -->
+    <record id="view_brains_classroom_search" model="ir.ui.view">
+        <field name="name">brains.classroom.search</field>
+        <field name="model">brains.classroom</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name"/>
+                <field name="campus_id"/>
+                <field name="year_id"/>
+                <field name="semester_id"/>
+                <field name="level_id"/>
+                <field name="cursus_id"/>
+                <field name="speciality_id"/>
+                <field name="faculty_id"/>
+                <filter string="By Campus" name="group_campus" context="{'group_by': 'campus_id'}"/>
+                <filter string="By Academic Year" name="group_year" context="{'group_by': 'year_id'}"/>
+                <filter string="By Semester" name="group_semester" context="{'group_by': 'semester_id'}"/>
+            </search>
+        </field>
+    </record>
+
+    <!-- ACTION -->
+    <record id="action_brains_classroom" model="ir.actions.act_window">
+        <field name="name">Classes</field>
+        <field name="res_model">brains.classroom</field>
+        <field name="view_mode">list,form</field>
+        <field name="view_id" ref="view_brains_classroom_list"/>
+        <field name="search_view_id" ref="view_brains_classroom_search"/>
+        <field name="context">{'group_by': ['campus_id','year_id']}</field>
+    </record>
+</odoo>

--- a/school/views/menu.xml
+++ b/school/views/menu.xml
@@ -91,11 +91,17 @@
                     sequence="4"/>
 
             <!-- Semestres -->
-            <menuitem id="menu_brains_semestre"   
-                    name="Semesters" 
+            <menuitem id="menu_brains_semestre"
+                    name="Semesters"
                     parent="cursus"
                     action="action_brains_semestre"
                     sequence="5"/>
+
+            <menuitem id="menu_brains_classroom"
+                    name="Classes"
+                    parent="cursus"
+                    action="action_brains_classroom"
+                    sequence="6"/>
 
         <!--  Employees -->
         <menuitem
@@ -112,6 +118,13 @@
             action="open_view_student_list_my"
             parent="menu_brains_root"
             sequence="9"/>
+
+        <menuitem
+            id="menu_brains_timetable"
+            name="Timetables"
+            action="action_brains_timetable"
+            parent="menu_brains_root"
+            sequence="9.5"/>
 
         <!-- Paramètres -->
         <menuitem id="menu_brains_settings" 

--- a/school/views/timetable.xml
+++ b/school/views/timetable.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- LIST VIEW -->
+    <record id="view_brains_timetable_list" model="ir.ui.view">
+        <field name="name">brains.timetable.list</field>
+        <field name="model">brains.timetable</field>
+        <field name="arch" type="xml">
+            <list string="Timetables" default_order="start_datetime asc">
+                <field name="name"/>
+                <field name="classroom_id"/>
+                <field name="course_id"/>
+                <field name="teacher_id"/>
+                <field name="campus_id"/>
+                <field name="semester_id"/>
+                <field name="year_id"/>
+                <field name="start_datetime"/>
+                <field name="end_datetime"/>
+                <field name="location"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- FORM VIEW -->
+    <record id="view_brains_timetable_form" model="ir.ui.view">
+        <field name="name">brains.timetable.form</field>
+        <field name="model">brains.timetable</field>
+        <field name="arch" type="xml">
+            <form string="Timetable">
+                <sheet>
+                    <group string="General Information">
+                        <field name="classroom_id"/>
+                        <field name="course_id" domain="[('semester_id','=',semester_id), ('years_id','=',year_id)]"/>
+                        <field name="teacher_id" domain="[('is_teacher','=',True)]"/>
+                        <field name="location"/>
+                    </group>
+                    <group string="Schedule">
+                        <field name="start_datetime"/>
+                        <field name="end_datetime"/>
+                    </group>
+                    <group string="Context" colspan="2">
+                        <field name="campus_id" readonly="1"/>
+                        <field name="semester_id" readonly="1"/>
+                        <field name="year_id" readonly="1"/>
+                        <field name="level_id" readonly="1"/>
+                        <field name="cursus_id" readonly="1"/>
+                        <field name="speciality_id" readonly="1"/>
+                    </group>
+                    <group string="Notes">
+                        <field name="notes" nolabel="1"/>
+                    </group>
+                </sheet>
+                <chatter reload_on_follower="True"/>
+            </form>
+        </field>
+    </record>
+
+    <!-- SEARCH VIEW -->
+    <record id="view_brains_timetable_search" model="ir.ui.view">
+        <field name="name">brains.timetable.search</field>
+        <field name="model">brains.timetable</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="classroom_id"/>
+                <field name="course_id"/>
+                <field name="teacher_id"/>
+                <field name="campus_id"/>
+                <field name="semester_id"/>
+                <field name="year_id"/>
+                <filter string="By Class" name="group_class" context="{'group_by': 'classroom_id'}"/>
+                <filter string="By Teacher" name="group_teacher" context="{'group_by': 'teacher_id'}"/>
+                <filter string="By Day" name="group_day" context="{'group_by': 'start_datetime:day'}"/>
+            </search>
+        </field>
+    </record>
+
+    <!-- ACTION -->
+    <record id="action_brains_timetable" model="ir.actions.act_window">
+        <field name="name">Timetables</field>
+        <field name="res_model">brains.timetable</field>
+        <field name="view_mode">calendar,list,form</field>
+        <field name="search_view_id" ref="view_brains_timetable_search"/>
+        <field name="context">{'search_default_group_class': 1}</field>
+    </record>
+
+    <record id="action_brains_timetable_calendar_view" model="ir.actions.act_window.view">
+        <field name="sequence" eval="1"/>
+        <field name="view_mode">calendar</field>
+        <field name="view_id" ref="view_brains_timetable_calendar"/>
+        <field name="act_window_id" ref="action_brains_timetable"/>
+    </record>
+
+    <record id="action_brains_timetable_tree_view" model="ir.actions.act_window.view">
+        <field name="sequence" eval="2"/>
+        <field name="view_mode">list</field>
+        <field name="view_id" ref="view_brains_timetable_list"/>
+        <field name="act_window_id" ref="action_brains_timetable"/>
+    </record>
+
+    <record id="action_brains_timetable_form_view" model="ir.actions.act_window.view">
+        <field name="sequence" eval="3"/>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="view_brains_timetable_form"/>
+        <field name="act_window_id" ref="action_brains_timetable"/>
+    </record>
+
+    <!-- CALENDAR VIEW -->
+    <record id="view_brains_timetable_calendar" model="ir.ui.view">
+        <field name="name">brains.timetable.calendar</field>
+        <field name="model">brains.timetable</field>
+        <field name="arch" type="xml">
+            <calendar string="Timetable" date_start="start_datetime" date_stop="end_datetime" color="classroom_id">
+                <field name="course_id"/>
+                <field name="teacher_id"/>
+                <field name="classroom_id"/>
+            </calendar>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- add a classroom model that links campus, semester, academic year, students, and teachers
- introduce timetable entries with scheduling constraints and calendar/list/form views
- expose the new models through security rules, menus, and manifest entries

## Testing
- python3 -m compileall school/models/timetable.py school/models/classroom.py school/models/cours.py

------
https://chatgpt.com/codex/tasks/task_e_68de81913810832cb2ac41d4bb589c32